### PR TITLE
Fix `makefile` flags on low memory devices

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -144,7 +144,7 @@ clean_apps() {
 
 build_apps() {
     ## Determine Ramsize and export MAKEFLAG
-     if [[ "$(get_avail_mem)" -le 524288 ]]; then
+    if [[ "$(get_avail_mem)" -le 524288 ]]; then
         USE_PROCS=-j1
     elif [[ "$(get_avail_mem)" -le 1048576 ]]; then
         USE_PROCS=-j2

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -144,15 +144,14 @@ clean_apps() {
 
 build_apps() {
     ## Determine Ramsize and export MAKEFLAG
-    if [[ "$(get_avail_mem)" -le 524288 ]]; then
+     if [[ "$(get_avail_mem)" -le 524288 ]]; then
         USE_PROCS=-j1
-    fi
-    if [[ "$(get_avail_mem)" -le 1048576 ]]; then
+    elif [[ "$(get_avail_mem)" -le 1048576 ]]; then
         USE_PROCS=-j2
-    fi
-    if [[ "$(get_avail_mem)" -gt 1048576 ]]; then
+    else
         USE_PROCS=-j4
     fi
+
     for path in "${ALL_PATHS[@]}"; do
         if [[ ! -d "${path}" ]]; then
             printf "'%s' does not exist! Build skipped ... [WARN]\n" "${path}"


### PR DESCRIPTION
On devices with less than 512MB existing devices will use `-j2` due to wrong condition.

